### PR TITLE
fix: Restrict Smooth Live Headers to Live Preview Mode

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -491,16 +491,16 @@ a:hover,
 	}
 }
 
-.cm-widgetBuffer + .cm-header {
+.is-live-preview .cm-widgetBuffer + .cm-header {
 	animation: outdent 250ms ease-out;
 	display: inline-block;
 }
 
-.cm-widgetBuffer + .cm-header.cm-formatting {
+.is-live-preview .cm-widgetBuffer + .cm-header.cm-formatting {
 	animation: opac 250ms ease-in;
 }
 
-.cm-active .cm-header + .cm-header {
+.is-live-preview .cm-active .cm-header + .cm-header {
 	animation: indent 250ms ease-out;
 	display: inline-block;
 }


### PR DESCRIPTION
Hi kneecaps,

I'm flattered to have a snippet beeing featured in this theme :)

I found out about it when I was wandering why the headers were still animating when toggeling off my snippet. I first thought it was a bug 😂

Here is a small fix to prevent it from animating in scource mode.

Thanks!
lukemt aka Luke#242

